### PR TITLE
Enable snprintf on FreeBSD

### DIFF
--- a/library/x509.c
+++ b/library/x509.c
@@ -31,7 +31,7 @@
 
 /* Ensure gmtime_r is available even with -std=c99; must be included before
  * config.h, which pulls in glibc's features.h. Harmless on other platforms. */
-#define _XOPEN_SOURCE 500
+#define _POSIX_C_SOURCE 200112L
 
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"


### PR DESCRIPTION
This PR changes the compatibility define so that the library builds on FreeBSD. I did local tests on a Debian and FreeBSD machines and I think it is ready to be submitted to the ARM's CI.